### PR TITLE
bug fixed

### DIFF
--- a/isolate/04-element-children/exercises/pass-the-tests-2.js
+++ b/isolate/04-element-children/exercises/pass-the-tests-2.js
@@ -17,7 +17,7 @@ console.log(divEl.nodeName, divEl.cloneNode(true));
 
 console.log(divEl.nodeName, divEl.cloneNode(true));
 
-console.assert(divEl.children[0].href === '#top',
+console.assert(divEl.children[0].getAttribute('href') === '#top',
   'Test: href');
 
 console.assert(divEl.children[0].children[0].innerHTML === 'to the top',


### PR DESCRIPTION
@colevandersWands  ` href gets the full path` whereas  `getAttribute() takes value of the href attribute`