### PR TITLE
bug:  write two different handlers

### DIFF
--- a/isolate/02-add-event-listener/examples/4-multiple-listeners-2.js
+++ b/isolate/02-add-event-listener/examples/4-multiple-listeners-2.js
@@ -10,8 +10,12 @@
 const buttonEl = document.createElement('button');
 
 // write two different handlers
-const helloHandler = () => {
-  alert('hello!');
+const firstHandler = () => {
+  alert('first handler');
+};
+
+const secondHandler = () => {
+  alert('second handler');
 };
 
 // call the handler when the button is clicked


### PR DESCRIPTION
This seems bug. It seems in a file the 2 separate handlers are forgotten to define. Thus causes  the following error:

VM81:18 Uncaught ReferenceError: firstHandler is not defined
    at eval (eval at <anonymous> (4-multiple-listeners-2.js?--defaults:2), <anonymous>:18:36)
    at <anonymous>:2:1
    at HTMLIFrameElement.evaller.onload (study-with.js:56)
    at Object.console (study-with.js:58)
    at JavaScriptFE.studyWith (javascript-class.js:463)
    at HTMLButtonElement.<anonymous> (javascript-class.js:290)